### PR TITLE
Added LED override commands

### DIFF
--- a/src/CommandInterface.cpp
+++ b/src/CommandInterface.cpp
@@ -95,10 +95,14 @@ bool CCommandInterface::SetPositionAbsolute()
 
 bool CCommandInterface::ShowHelp()
 {
-  mClient.write("Version: 0.0.4        : just a version for now.\n");
+  mClient.write("Version: 0.0.5        : 0.0.5: Added LED override commands.\n");
+  mClient.write("                      : 0.0.4: Just a first version.\n\n");
 
-  mClient.write("reboot                : Reboots the system.\n");
+  mClient.write("reboot                : Reboots the system.\n\n");
 
+  // Config space related commands
+  mClient.write("load                  : Load configuration settings from storage.\n"); //@JB: Added the load command,
+                                                                                        // but not sure why it is here?
   mClient.write("set hostname [value]  : Sets the device hostname name for wifi network.\n");
   mClient.write("                        In accesspoint mode the hostname is used as ssid.\n");
   mClient.write("get hostname          : Gets the device hostname.\n\n");
@@ -118,15 +122,23 @@ bool CCommandInterface::ShowHelp()
 
   mClient.write("set preset [value]    : Sets the specified preset to the current position.\n");
   mClient.write("                        Valid range: 1 .. 4\n");
-  mClient.write("get preset            : Gets the position for the specified preset.\n");
+  mClient.write("get preset            : Gets the position for the specified preset.\n\n");
+
+  mClient.write("save                  : Save configuration changes.\n\n");
+  // end config space related commands
 
   mClient.write("set pos [value]       : Sets the position of the axis.\n");
   mClient.write("                        0 .. 100 move to absolute position in percentage of the total stroke.\n");
   mClient.write("                        -100 .. +100 move relative in percentage of the total stroke.\n");
   mClient.write("                        p1 .. p4 move to preset position.\n");
-  mClient.write("get pos               : Gets the current position of the axis.\n");
+  mClient.write("get pos               : Gets the current position of the axis.\n\n");
 
-  mClient.write("save                  : Save configuration changes.\n\n");
+  mClient.write("set led1red            : Forces LED1 to red.\n");
+  mClient.write("set led1green          : Forces LED1 to green.\n");
+  mClient.write("set led1redgreen       : Forces LED1 to green.\n");
+  mClient.write("set led1off            : Forces LED1 to red.\n");
+  mClient.write("set led1release        : Releases LED1 to normal behavior.\n\n");
+
   return true;
 }
 
@@ -225,6 +237,35 @@ bool CCommandInterface::Set()
   if (txt == "pos")
     return SetPosition();
 
+  if (txt == "led1red")
+  {
+    CSystem::Get().GetStatus().SetLed1Override(ELedOverride::ForceRed);
+    return true;
+  }
+
+  if (txt == "led1green")
+  {
+    CSystem::Get().GetStatus().SetLed1Override(ELedOverride::ForceGreen);
+    return true;
+  }
+
+  if (txt == "led1redgreen")
+  {
+    CSystem::Get().GetStatus().SetLed1Override(ELedOverride::ForceRedGreen);
+    return true;
+  }
+
+  if (txt == "led1off")
+  {
+    CSystem::Get().GetStatus().SetLed1Override(ELedOverride::ForceOff);
+    return true;
+  }
+
+  if (txt == "led1release")
+  {
+    CSystem::Get().GetStatus().SetLed1Override(ELedOverride::Release);
+    return true;
+  }
   Log::Error("Unexpected keyword: '{}'", txt);
   return false;
 }

--- a/src/Status.cpp
+++ b/src/Status.cpp
@@ -26,13 +26,13 @@ void CStatus::SetBooting(bool enable)
 void CStatus::SetMoving(bool enable)
 {
   if (!mOverrideLed1)
-  {
-    mMoving = enable;
-    if (mMoving)
-      mRedLed.On();
-    else
-      mRedLed.Off();
-  }
+    return;
+
+  mMoving = enable;
+  if (mMoving)
+    mRedLed.On();
+  else
+    mRedLed.Off();
 }
 
 void CStatus::SetAccessPoint(bool enable)

--- a/src/Status.cpp
+++ b/src/Status.cpp
@@ -25,20 +25,58 @@ void CStatus::SetBooting(bool enable)
 
 void CStatus::SetMoving(bool enable)
 {
-  mMoving = enable;
-  if (mMoving)
-    mRedLed.On();
-  else
-    mRedLed.Off();
+  if (!mOverrideLed1)
+  {
+    mMoving = enable;
+    if (mMoving)
+      mRedLed.On();
+    else
+      mRedLed.Off();
+  }
 }
 
 void CStatus::SetAccessPoint(bool enable)
 {
-  mAccessPoint = enable;
-  if (mAccessPoint)
-    mGreenLed.Blink(1000);
-  else
+  if (!mOverrideLed1)
+  {
+    mAccessPoint = enable;
+    if (mAccessPoint)
+      mGreenLed.Blink(1000);
+    else
+      mGreenLed.Off();
+  }
+}
+
+void CStatus::SetLed1Override(ELedOverride override)
+{
+  switch (override)
+  {
+  case ELedOverride::Release:
+    mRedLed.Off();
     mGreenLed.Off();
+    mOverrideLed1 = false; // Turn LED off and revert to normal status function
+    break;
+  case ELedOverride::ForceRed:
+    mOverrideLed1 = true;
+    mRedLed.On();
+    mGreenLed.Off();
+    break;
+  case ELedOverride::ForceGreen:
+    mOverrideLed1 = true;
+    mRedLed.Off();
+    mGreenLed.On();
+    break;
+  case ELedOverride::ForceRedGreen:
+    mOverrideLed1 = true;
+    mRedLed.On();
+    mGreenLed.On();
+    break;
+  case ELedOverride::ForceOff:
+    mRedLed.Off();
+    mGreenLed.Off();
+    mOverrideLed1 = true;
+    break;
+  }
 }
 
 void CStatus::Handler()

--- a/src/Status.h
+++ b/src/Status.h
@@ -5,6 +5,16 @@
 
 #include <cstdint>
 
+// RVC should this enum class be in a namespace?
+enum class ELedOverride
+{
+  Release,  // Do not override LEDs anymore
+  ForceRed, // Force LED to red
+  ForceGreen,
+  ForceRedGreen,
+  ForceOff // Force LED off
+};
+
 class CStatus
 {
 public:
@@ -24,6 +34,7 @@ public:
   void SetBooting(bool enable);
   void SetMoving(bool enable);
   void SetAccessPoint(bool enable);
+  void SetLed1Override(ELedOverride override);
 
 protected:
   CLed mSystemLed;
@@ -32,4 +43,5 @@ protected:
   bool mBooting = true;
   bool mMoving = false;
   bool mAccessPoint = false;
+  bool mOverrideLed1 = false; // Override for LED1 (mGreenLed + mRedLed)
 };


### PR DESCRIPTION
Only created for the bicolor LED called LED1. Do not think it makes sense for the system LED, but perhaps later for the new added blue LED called LED2?